### PR TITLE
feat(ui): allow chain play

### DIFF
--- a/src/main/java/com/jsimforest/Client.java
+++ b/src/main/java/com/jsimforest/Client.java
@@ -357,6 +357,9 @@ public class Client extends Application implements PropertyChangeListener {
         playSVG.setFill(Color.WHITE);
         playButton.getStyleClass().add("controlButton");
         playButton.setOnMouseClicked((event) -> {
+            if (this.simulation.getStep() == (this.simulationConfig.getStepsNumber() + 1)) {
+                this.simulation.setStep(0);
+            }
             if (!this.simulation.isPause() && this.simulation.getStep() == 0) {
                 this.initialState = new Simulation(this.simulationConfig);
                 this.initialState.getGrid().setMatrix((ArrayList<ArrayList<Cell>>) this.simulation.getGrid().clone());


### PR DESCRIPTION
- allowed user to click chain simulations by setting simulation.step to 0 if the number of steps has reached the max of the configuration
- allowed minimum grid to be 3*3 (instead of 4*4)
- fixed tests by initializing Configuration & Simulation in Client
- reformatted Client